### PR TITLE
Support more error types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Support of more kind of FormError
+
 ### Changed
 - Huge BC Break on namespaces. You need to rename all classes used to SwagIndustries instead of Biig
 

--- a/src/Bridge/Symfony/Response/FormErrorResponse.php
+++ b/src/Bridge/Symfony/Response/FormErrorResponse.php
@@ -94,6 +94,14 @@ class FormErrorResponse extends AbstractUserDataErrorResponse
         $propertyPath = $this->resolvePropertyPath($formError->getOrigin());
         $cause = $formError->getCause();
 
+        if (null === $cause) {
+            return [$formError->getMessage(), $propertyPath];
+        }
+
+        if (is_string($cause)) {
+            return [$cause, $propertyPath];
+        }
+
         if ('Symfony\\Component\\Security\\Csrf\\CsrfToken' === get_class($cause)) {
             return ['csrf token', $propertyPath];
         }


### PR DESCRIPTION
When the user defines its own form error, in many cases the cause will
not be specified so we render the form error directly instead.

If the user wants to change this behavior he can extends the
FormErrorResponse anyway.

Fix https://github.com/swagindustries/Melodiia/issues/13