### PR TITLE
Make security optional in crud controllers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Huge BC Break on namespaces. You need to rename all classes used to SwagIndustries instead of Biig
+- BC Break on CRUD classes. It's big changes time. So we made the security optional for crud controllers, this has a
+  consequence on their constructor
 
 ## [0.6.0] 2020-06-01
 ### Added

--- a/docs/Crud.md
+++ b/docs/Crud.md
@@ -1,6 +1,18 @@
 CRUDs with Melodiia
 ===================
 
+Requirements
+------------
+
+The CRUD of Melodiia is based on the following components of Symfony. This means you need to use install & enable them:
+- **The Serializer Component**
+  
+  Melodiia uses the serializer of Symfony to render responses.
+- **The Form Component**
+  
+  Melodiia uses the form component to manage input.
+
+
 Register your first CRUD
 ------------------------
 
@@ -36,7 +48,6 @@ acme_article_get:
     defaults:
         melodiia_model: App\Entity\Article
         melodiia_security_check: 'some content runnable in AuthorizationChecker class'
-
 ```
 
 #### Collection

--- a/src/Bridge/Symfony/Resources/config/crud.yaml
+++ b/src/Bridge/Symfony/Resources/config/crud.yaml
@@ -27,7 +27,7 @@ services:
             $dataStore: '@melodiia.doctrine.data_provider'
             $formFactory: '@form.factory'
             $dispatcher: '@event_dispatcher'
-            $checker: '@security.authorization_checker'
+            $checker: '@?security.authorization_checker'
         tags: [ controller.service_arguments ]
 
     melodiia.crud.controller.update:
@@ -36,32 +36,32 @@ services:
             $dataStore: '@melodiia.doctrine.data_provider'
             $formFactory: '@form.factory'
             $dispatcher: '@event_dispatcher'
-            $checker: '@security.authorization_checker'
             $idResolver: '@melodiia.crud.id_resolver'
+            $checker: '@?security.authorization_checker'
         tags: [ controller.service_arguments ]
 
     melodiia.crud.controller.get_all:
         class: SwagIndustries\Melodiia\Crud\Controller\GetAll
         arguments:
             $dataStore: '@melodiia.doctrine.data_provider'
-            $checker: '@security.authorization_checker'
             $collectionFactory: '@melodiia.crud.filters.filter_collection_factory'
             $pagesRequestFactory: '@SwagIndustries\Melodiia\Crud\Pagination\PaginationRequestFactoryInterface'
+            $checker: '@?security.authorization_checker'
         tags: [ controller.service_arguments ]
 
     melodiia.crud.controller.get:
         class: SwagIndustries\Melodiia\Crud\Controller\Get
         arguments:
             $dataStore: '@melodiia.doctrine.data_provider'
-            $checker: '@security.authorization_checker'
             $idResolver: '@melodiia.crud.id_resolver'
+            $checker: '@?security.authorization_checker'
         tags: [ controller.service_arguments ]
 
     melodiia.crud.controller.delete:
         class: SwagIndustries\Melodiia\Crud\Controller\Delete
         arguments:
             $dataStore: '@melodiia.doctrine.data_provider'
-            $checker: '@security.authorization_checker'
             $dispatcher: '@event_dispatcher'
             $idResolver: '@melodiia.crud.id_resolver'
+            $checker: '@?security.authorization_checker'
         tags: [ controller.service_arguments ]

--- a/src/Crud/Controller/CrudControllerTrait.php
+++ b/src/Crud/Controller/CrudControllerTrait.php
@@ -5,7 +5,10 @@ declare(strict_types=1);
 namespace SwagIndustries\Melodiia\Crud\Controller;
 
 use SwagIndustries\Melodiia\Crud\CrudableModelInterface;
+use SwagIndustries\Melodiia\Crud\CrudControllerInterface;
 use SwagIndustries\Melodiia\Exception\MelodiiaLogicException;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
 trait CrudControllerTrait
 {
@@ -18,6 +21,24 @@ trait CrudControllerTrait
     {
         if (empty($modelClass) || !class_exists($modelClass) || !is_subclass_of($modelClass, CrudableModelInterface::class)) {
             throw new MelodiiaLogicException('If you use melodiia CRUD classes, you need to specify a model.');
+        }
+    }
+
+    private function assertResourceRights(Request $request, $data = null)
+    {
+        $securityCheck = $request->attributes->get(CrudControllerInterface::SECURITY_CHECK, null);
+        $modelClass = $request->attributes->get(CrudControllerInterface::MODEL_ATTRIBUTE);
+
+        if (null === $securityCheck) {
+            return;
+        }
+
+        if (!$this->checker) {
+            throw new MelodiiaLogicException('The security component of Symfony seems to not be enabled');
+        }
+
+        if (($data && !$this->checker->isGranted($securityCheck, $data)) || !$this->checker->isGranted($securityCheck)) {
+            throw new AccessDeniedException(\sprintf('Access denied to data of type "%s".', $modelClass));
         }
     }
 }

--- a/src/Crud/Controller/Delete.php
+++ b/src/Crud/Controller/Delete.php
@@ -14,7 +14,6 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
-use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
 final class Delete extends BaseCrudController implements CrudControllerInterface
 {
@@ -26,24 +25,23 @@ final class Delete extends BaseCrudController implements CrudControllerInterface
     /** @var DataStoreInterface */
     private $dataStore;
 
-    /** @var AuthorizationCheckerInterface */
+    /** @var AuthorizationCheckerInterface|null */
     private $checker;
 
     /** @var IdResolverInterface */
     private $idResolver;
 
-    public function __construct(DataStoreInterface $dataStore, AuthorizationCheckerInterface $checker, EventDispatcherInterface $dispatcher, IdResolverInterface $idResolver = null)
+    public function __construct(DataStoreInterface $dataStore, EventDispatcherInterface $dispatcher, IdResolverInterface $idResolver = null, AuthorizationCheckerInterface $checker = null)
     {
         parent::__construct($dispatcher);
         $this->dataStore = $dataStore;
-        $this->checker = $checker;
         $this->idResolver = $idResolver ?? new SimpleIdResolver();
+        $this->checker = $checker;
     }
 
     public function __invoke(Request $request)
     {
         $modelClass = $request->attributes->get(self::MODEL_ATTRIBUTE);
-        $securityCheck = $request->attributes->get(self::SECURITY_CHECK, null);
 
         try {
             $id = $this->idResolver->resolveId($request, $modelClass);
@@ -59,9 +57,7 @@ final class Delete extends BaseCrudController implements CrudControllerInterface
             throw new NotFoundHttpException(\sprintf('resource item "%s" with id "%s" can not be found', $modelClass, $id));
         }
 
-        if ($securityCheck && !$this->checker->isGranted($securityCheck, $data)) {
-            throw new AccessDeniedException(\sprintf('You can\'t perform a delete operation of the resource item "%s" with id "%s"', $modelClass, $id));
-        }
+        $this->assertResourceRights($request, $data);
 
         $this->dispatch(new CrudEvent($data), self::EVENT_PRE_DELETE);
         $this->dataStore->remove($data);

--- a/tests/Melodiia/Crud/Controller/DeleteTest.php
+++ b/tests/Melodiia/Crud/Controller/DeleteTest.php
@@ -59,9 +59,9 @@ class DeleteTest extends TestCase
 
         $this->controller = new Delete(
             $this->dataStore->reveal(),
-            $this->checker->reveal(),
             $this->dispatcher->reveal(),
-            $idResolver->reveal()
+            $idResolver->reveal(),
+            $this->checker->reveal()
         );
     }
 

--- a/tests/Melodiia/Crud/Controller/GetAllTest.php
+++ b/tests/Melodiia/Crud/Controller/GetAllTest.php
@@ -82,9 +82,9 @@ class GetAllTest extends TestCase
 
         $this->controller = new GetAll(
             $this->dataStore->reveal(),
-            $this->authorizationChecker->reveal(),
             $this->filtersFactory->reveal(),
-            $paginationFactory->reveal()
+            $paginationFactory->reveal(),
+            $this->authorizationChecker->reveal()
         );
     }
 

--- a/tests/Melodiia/Crud/Controller/GetTest.php
+++ b/tests/Melodiia/Crud/Controller/GetTest.php
@@ -35,7 +35,7 @@ class GetTest extends TestCase
         $idResolver = $this->prophesize(IdResolverInterface::class);
         $idResolver->resolveId(Argument::type(Request::class), Argument::type('string'))->willReturn('id');
 
-        $this->controller = new Get($this->dataStore->reveal(), $this->authorizationChecker->reveal(), $idResolver->reveal());
+        $this->controller = new Get($this->dataStore->reveal(), $idResolver->reveal(), $this->authorizationChecker->reveal());
     }
 
     public function testItIsIntanceOfMelodiiaController()

--- a/tests/Melodiia/Crud/Controller/UpdateTest.php
+++ b/tests/Melodiia/Crud/Controller/UpdateTest.php
@@ -82,8 +82,8 @@ class UpdateTest extends TestCase
             $this->dataStore->reveal(),
             $this->formFactory->reveal(),
             $this->dispatcher->reveal(),
-            $this->checker->reveal(),
-            $idResolver->reveal()
+            $idResolver->reveal(),
+            $this->checker->reveal()
         );
     }
 


### PR DESCRIPTION
This commit removes a mandatory dependency for CRUD controllers. An exception will be throw in case the user didn't configure the security component but security for Melodiia.

It comes with a huge BC break because it required to change the order of the properties while those controllers are designed to be extendable. I allowed this break to happen because we break on many things for the rebranding.