### PR TITLE
Remove the requirement to CSRF extension of Sf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Support of more kind of FormError
+- Removed requirement to have CSRF protection enabled #25
 
 ### Changed
 - Huge BC Break on namespaces. You need to rename all classes used to SwagIndustries instead of Biig

--- a/src/Crud/FilterCollection.php
+++ b/src/Crud/FilterCollection.php
@@ -2,8 +2,8 @@
 
 namespace SwagIndustries\Melodiia\Crud;
 
+use SwagIndustries\Melodiia\Bridge\Symfony\Form\Type\ApiType;
 use SwagIndustries\Melodiia\Exception\NoFormFilterCreatedException;
-use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
 
@@ -53,9 +53,8 @@ class FilterCollection implements FilterCollectionInterface
             return $this->form;
         }
 
-        $builder = $this->formFactory->createNamedBuilder('', FormType::class, null, [
+        $builder = $this->formFactory->createNamedBuilder('', ApiType::class, null, [
             'method' => 'GET',
-            'csrf_protection' => false,
             'allow_extra_fields' => true,
         ]);
 


### PR DESCRIPTION
While building the functional test suite I figure out that the CSRF extension was required to make melodiia work while the only thing it does is actually disabling it!

This was because the form type used in the filter was not the ApiType. This commit only fix that.