### PR TITLE
Headers in api response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - There is a new optional option on the ApiType: `clear_missing` but its value is automatically guessed by default
       to follow HTTP verbs.
 - Removal of the dependency to zend json (thanks to php 7.3 upgrade)
+- BC Break: the ApiResponse now contains also headers. If you do not extends another response you will need to add the missing method
 
 ## [0.6.0] 2020-06-01
 ### Added

--- a/src/Response/AbstractApiResponse.php
+++ b/src/Response/AbstractApiResponse.php
@@ -18,4 +18,9 @@ abstract class AbstractApiResponse implements ApiResponse
     {
         return $this->message;
     }
+
+    public function headers(): array
+    {
+        return [];
+    }
 }

--- a/src/Response/AbstractUserDataErrorResponse.php
+++ b/src/Response/AbstractUserDataErrorResponse.php
@@ -17,4 +17,9 @@ abstract class AbstractUserDataErrorResponse implements ApiResponse
     {
         return 400;
     }
+
+    public function headers(): array
+    {
+        return [];
+    }
 }

--- a/src/Response/ApiResponse.php
+++ b/src/Response/ApiResponse.php
@@ -7,4 +7,6 @@ namespace SwagIndustries\Melodiia\Response;
 interface ApiResponse
 {
     public function httpStatus(): int;
+
+    public function headers(): array;
 }

--- a/src/Response/Created.php
+++ b/src/Response/Created.php
@@ -35,4 +35,9 @@ class Created implements ApiResponse
     {
         return 201;
     }
+
+    public function headers(): array
+    {
+        return [];
+    }
 }

--- a/src/Response/Listener/SerializeOnKernelView.php
+++ b/src/Response/Listener/SerializeOnKernelView.php
@@ -53,7 +53,7 @@ class SerializeOnKernelView implements EventSubscriberInterface
             new JsonResponse(
                 $this->serializer->serialize($response, 'json', $context),
                 $response->httpStatus(),
-                [],
+                $response->headers(),
                 true
             )
         );

--- a/src/Response/Ok.php
+++ b/src/Response/Ok.php
@@ -4,21 +4,8 @@ declare(strict_types=1);
 
 namespace SwagIndustries\Melodiia\Response;
 
-class Ok implements ApiResponse
+class Ok extends AbstractApiResponse
 {
-    /** @var string */
-    private $message;
-
-    public function __construct(string $message)
-    {
-        $this->message = $message;
-    }
-
-    public function getMessage(): string
-    {
-        return $this->message;
-    }
-
     public function httpStatus(): int
     {
         return 200;

--- a/src/Response/OkContent.php
+++ b/src/Response/OkContent.php
@@ -36,4 +36,9 @@ class OkContent implements ApiResponse, SerializationContextAwareInterface
     {
         return 200;
     }
+
+    public function headers(): array
+    {
+        return [];
+    }
 }

--- a/tests/Melodiia/Response/Listener/SerializeOnKernelViewTest.php
+++ b/tests/Melodiia/Response/Listener/SerializeOnKernelViewTest.php
@@ -11,6 +11,7 @@ use SwagIndustries\Melodiia\Response\ApiResponse;
 use SwagIndustries\Melodiia\Response\Listener\SerializeOnKernelView;
 use SwagIndustries\Melodiia\Serialization\Context\ContextBuilderChainInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\ViewEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
@@ -56,6 +57,11 @@ class SerializeOnKernelViewTest extends TestCase
             {
                 return 200;
             }
+
+            public function headers(): array
+            {
+                return [];
+            }
         };
         $this->serializer->serialize($response, Argument::cetera())->shouldBeCalled()->willReturn('"hello"');
         $event = new ViewEvent(
@@ -66,5 +72,7 @@ class SerializeOnKernelViewTest extends TestCase
         );
 
         $this->listener->onKernelView($event);
+
+        $this->assertInstanceOf(JsonResponse::class, $event->getResponse());
     }
 }


### PR DESCRIPTION
I'm not really sure of this one. It's free break. I'm just doing it because we can break at this point.

- Pro: we can break and it's important
- Con: we nearly never specify response headers and in this case redefining the SerializeOnKernelView service is fine


WDYT @mcsky ?