### PR TITLE
feat: new way to configure doc path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.8.0] 2020-11-26
+## [0.9.0] 2021-12-10
+### Added
+- Compatibility with PHP 8.1
+
+### Changed
+- Fix #54 to be able to build a melodiia application on any PAAS service
+
+## [0.8.0] 2021-11-26
 ### Added
 - Add json-api header in responses
 

--- a/UPGRADE-0.9.md
+++ b/UPGRADE-0.9.md
@@ -1,0 +1,4 @@
+Upgrade guide 0.8...0.9
+=======================
+
+Use the new configuration key `openapi_path` instead of `documentation_file_path` to configure your documentation routing.

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -9,6 +9,7 @@ melodiia:
         # Define as much APIs you want here.
         main:
             base_path: /api/v1
+            openapi_path: /path/to/your/openapi/doc.yaml
             pagination:
                 # Using this query attribute you can change the max per page
                 max_per_page_attribute: max_per_page

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -113,11 +113,23 @@ to configure the OpenAPI documentation in a good way was a serious pain and was 
 But it comes with some help to build your documentation:
 1. Run `bin/console assets:insall`
 2. Create a file `documentation.yml` (the `config` folder seems like a good location)
-2. Add the following routing to your configuration
+3. Add your documentation file in the global melodiia configuration and configure your documentation route
 
 ```yaml
-# The documentation should be available only in dev environment
-# routing_dev.yaml
+# /config/packages/melodiia.yaml
+melodiia:
+    apis:
+        main:
+            # Required all the time! Do not forget this!
+            base_path:    /api/v1
+            
+            # This is what we are looking for here:
+            openapi_path: /path/to/your/openapi/doc.yaml
+```
+
+```yaml
+# The documentation should be available only in dev environment in some cases
+# /config/routing_dev.yaml
 documentation:
     path: /documentation
     controller: 'melodiia.documentation'

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace SwagIndustries\Melodiia\DependencyInjection;
 
+use SwagIndustries\Melodiia\MelodiiaConfiguration;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
@@ -28,6 +29,7 @@ class Configuration implements ConfigurationInterface
                     ->arrayPrototype()
                         ->children()
                             ->scalarNode('base_path')->defaultValue('/')->end()
+                            ->scalarNode(MelodiiaConfiguration::CONFIGURATION_OPENAPI_PATH)->defaultNull()->end()
                             ->arrayNode('pagination')
                                 ->addDefaultsIfNotSet()
                                 ->children()

--- a/src/DependencyInjection/MelodiiaExtension.php
+++ b/src/DependencyInjection/MelodiiaExtension.php
@@ -50,7 +50,7 @@ class MelodiiaExtension extends Extension
             // This is just a helpful layer in case some dependency is missing, because twig is optional.
             foreach ($config['api'] as $endpoint) {
                 if (!empty($endpoint[MelodiiaConfiguration::CONFIGURATION_OPENAPI_PATH])) {
-                    throw new DependencyMissingException('You specified a documentation path but twig is not activated. Melodiia will not be able to render your documentation.');
+                    throw new DependencyMissingException('You specified a documentation path but twig is not installed. Melodiia will not be able to render your documentation.');
                 }
             }
         }

--- a/src/DependencyInjection/MelodiiaExtension.php
+++ b/src/DependencyInjection/MelodiiaExtension.php
@@ -6,6 +6,8 @@ namespace SwagIndustries\Melodiia\DependencyInjection;
 
 use Doctrine\Persistence\AbstractManagerRegistry;
 use SwagIndustries\Melodiia\Crud\FilterInterface;
+use SwagIndustries\Melodiia\Exception\DependencyMissingException;
+use SwagIndustries\Melodiia\MelodiiaConfiguration;
 use SwagIndustries\Melodiia\Serialization\Context\ContextBuilderInterface;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -28,6 +30,9 @@ class MelodiiaExtension extends Extension
         $xmlLoader = new XmlFileLoader($container, $configFileLocator);
         $xmlLoader->load('error-management.xml');
 
+        $configuration = new Configuration();
+        $config = $this->processConfiguration($configuration, $configs);
+
         if (class_exists(AbstractManagerRegistry::class)) {
             $loader->load('doctrine.yaml');
         }
@@ -41,10 +46,14 @@ class MelodiiaExtension extends Extension
 
         if (class_exists(Environment::class)) {
             $loader->load('twig.yaml');
+        } elseif ('dev' === $container->getParameter('kernel.environment')) {
+            // This is just a helpful layer in case some dependency is missing, because twig is optional.
+            foreach ($config['api'] as $endpoint) {
+                if (!empty($endpoint[MelodiiaConfiguration::CONFIGURATION_OPENAPI_PATH])) {
+                    throw new DependencyMissingException('You specified a documentation path but twig is not activated. Melodiia will not be able to render your documentation.');
+                }
+            }
         }
-
-        $configuration = new Configuration();
-        $config = $this->processConfiguration($configuration, $configs);
 
         $container->setParameter('melodiia.config', $config);
 

--- a/src/Exception/DependencyMissingException.php
+++ b/src/Exception/DependencyMissingException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SwagIndustries\Melodiia\Exception;
+
+class DependencyMissingException extends MelodiiaLogicException
+{
+}

--- a/src/MelodiiaConfiguration.php
+++ b/src/MelodiiaConfiguration.php
@@ -9,6 +9,7 @@ use Symfony\Component\HttpFoundation\Request;
 final class MelodiiaConfiguration implements MelodiiaConfigurationInterface
 {
     public const PREFIX_CONTROLLER = 'melodiia.crud.controller';
+    public const CONFIGURATION_OPENAPI_PATH = 'openapi_path';
 
     /**
      * @var array

--- a/src/MelodiiaConfigurationInterface.php
+++ b/src/MelodiiaConfigurationInterface.php
@@ -7,7 +7,7 @@ namespace SwagIndustries\Melodiia;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
- * @internal inheritance
+ * @internal for testing purpose, you should implement this interface
  */
 interface MelodiiaConfigurationInterface
 {

--- a/src/Resources/config/twig.yaml
+++ b/src/Resources/config/twig.yaml
@@ -4,3 +4,4 @@ services:
         tags: ['controller.service_arguments']
         arguments:
             $templating: '@twig'
+            $configuration: '@melodiia.configuration'

--- a/tests/TestApplication/config/melodiia.yaml
+++ b/tests/TestApplication/config/melodiia.yaml
@@ -1,3 +1,4 @@
 melodiia:
     apis:
-        main: ~
+        main:
+            openapi_path: '%kernel.project_dir%/config/documentation.yaml'

--- a/tests/TestApplication/config/routing_dev.yaml
+++ b/tests/TestApplication/config/routing_dev.yaml
@@ -2,5 +2,3 @@
 documentation:
     path: /documentation
     controller: 'melodiia.documentation'
-    defaults:
-        documentation_file_path: '%kernel.project_dir%/config/documentation.yaml'


### PR DESCRIPTION
This should fix #54 

Not a big fan of this new way because if you configure that, to me you expect the controller to be registered automatically.

The problem with the automatic approach is that it means we need to have more config such has:
```yaml
documentation:
    openapi_path: ''
    path: ''
```

Which looks a lot like routing....