### PR TITLE
:bug: Fix wrong detection of wrong configuration

### DIFF
--- a/src/DependencyInjection/MelodiiaExtension.php
+++ b/src/DependencyInjection/MelodiiaExtension.php
@@ -48,7 +48,8 @@ class MelodiiaExtension extends Extension
             $loader->load('twig.yaml');
         } elseif ('dev' === $container->getParameter('kernel.environment')) {
             // This is just a helpful layer in case some dependency is missing, because twig is optional.
-            foreach ($config['api'] as $endpoint) {
+            $endpoints = $config['apis'] ?? [];
+            foreach ($endpoints as $endpoint) {
                 if (!empty($endpoint[MelodiiaConfiguration::CONFIGURATION_OPENAPI_PATH])) {
                     throw new DependencyMissingException('You specified a documentation path but twig is not installed. Melodiia will not be able to render your documentation.');
                 }

--- a/tests/Behat/Context/AbstractContext.php
+++ b/tests/Behat/Context/AbstractContext.php
@@ -38,6 +38,7 @@ abstract class AbstractContext implements Context
 
         if ('GET' === $verb) {
             $client->request($verb, $uri);
+
             return self::$response = $client->getResponse();
         }
 
@@ -47,6 +48,7 @@ abstract class AbstractContext implements Context
         json_decode($rawContent, true, 512, \JSON_THROW_ON_ERROR);
 
         $client->request($verb, $uri, [], [], [], $rawContent);
+
         return self::$response = $client->getResponse();
     }
 
@@ -58,7 +60,7 @@ abstract class AbstractContext implements Context
         }
     }
 
-    final static protected function getLastResponse(): Response
+    final protected static function getLastResponse(): Response
     {
         if (null === self::$response) {
             throw new \LogicException('It seems you didn\'t do any requests yet');

--- a/tests/Behat/Context/ErrorContext.php
+++ b/tests/Behat/Context/ErrorContext.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace SwagIndustries\Melodiia\Tests\Behat\Context;


### PR DESCRIPTION
If twig is not installed, Melodiia checks the configuration to throw an informative error in case it is required to work. However, this verification was not working well. This is the fix!