### PR TITLE
:sparkles: Fix some deprecations notice (Sf 6.x compat)

### DIFF
--- a/src/Serialization/Json/CreatedNormalizer.php
+++ b/src/Serialization/Json/CreatedNormalizer.php
@@ -9,7 +9,7 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 class CreatedNormalizer implements NormalizerInterface
 {
-    public function normalize($object, string $format = null, array $context = [])
+    public function normalize($object, string $format = null, array $context = []): array
     {
         $res = [];
         $resource = $object->getResourceId();
@@ -22,7 +22,7 @@ class CreatedNormalizer implements NormalizerInterface
         return $res;
     }
 
-    public function supportsNormalization($data, string $format = null)
+    public function supportsNormalization($data, string $format = null): bool
     {
         return is_object($data) && $data instanceof Created;
     }

--- a/src/Serialization/Json/ErrorNormalizer.php
+++ b/src/Serialization/Json/ErrorNormalizer.php
@@ -15,7 +15,7 @@ class ErrorNormalizer implements NormalizerInterface
      *
      * @return array|bool|float|int|string
      */
-    public function normalize($object, $format = null, array $context = [])
+    public function normalize($object, $format = null, array $context = []): array
     {
         $res = ['violations' => []];
 
@@ -26,7 +26,7 @@ class ErrorNormalizer implements NormalizerInterface
         return $res;
     }
 
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null): bool
     {
         return is_object($data) && $data instanceof AbstractUserDataErrorResponse;
     }

--- a/src/Serialization/Json/ExceptionNormalizer.php
+++ b/src/Serialization/Json/ExceptionNormalizer.php
@@ -19,7 +19,7 @@ final class ExceptionNormalizer implements NormalizerInterface
         $this->debug = $debug;
     }
 
-    public function normalize($object, $format = null, array $context = [])
+    public function normalize($object, $format = null, array $context = []): array
     {
         $data = [
             'title' => 'An error occurred',
@@ -33,7 +33,7 @@ final class ExceptionNormalizer implements NormalizerInterface
         return $data;
     }
 
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null): bool
     {
         if (class_exists(FlattenException::class)) {
             return $data instanceof \Exception || $data instanceof FlattenException;

--- a/src/Serialization/Json/OkContentNormalizer.php
+++ b/src/Serialization/Json/OkContentNormalizer.php
@@ -109,7 +109,7 @@ class OkContentNormalizer implements NormalizerInterface, SerializerAwareInterfa
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null): bool
     {
         return is_object($data) && $data instanceof OkContent;
     }


### PR DESCRIPTION
Symfony throws deprecation notice if the method does not follow the parent comment declaration. This should make our code more compatible with Symfony 6.x and remove the deprecation notice in Symfony 5.4