### PR TITLE
Improve Symfony 6 compatibility

### DIFF
--- a/src/Serialization/Json/CreatedNormalizer.php
+++ b/src/Serialization/Json/CreatedNormalizer.php
@@ -26,4 +26,11 @@ class CreatedNormalizer implements NormalizerInterface
     {
         return is_object($data) && $data instanceof Created;
     }
+
+    public function getSupportedTypes(?string $format): array
+    {
+        return [
+            Created::class => true,
+        ];
+    }
 }

--- a/src/Serialization/Json/ErrorNormalizer.php
+++ b/src/Serialization/Json/ErrorNormalizer.php
@@ -30,4 +30,11 @@ class ErrorNormalizer implements NormalizerInterface
     {
         return is_object($data) && $data instanceof AbstractUserDataErrorResponse;
     }
+
+    public function getSupportedTypes(?string $format): array
+    {
+        return [
+            AbstractUserDataErrorResponse::class => true,
+        ];
+    }
 }

--- a/src/Serialization/Json/ExceptionNormalizer.php
+++ b/src/Serialization/Json/ExceptionNormalizer.php
@@ -61,4 +61,11 @@ final class ExceptionNormalizer implements NormalizerInterface
 
         return $message;
     }
+
+    public function getSupportedTypes(?string $format): array
+    {
+        return [
+            FlattenException::class => true,
+        ];
+    }
 }

--- a/src/Serialization/Json/OkContentNormalizer.php
+++ b/src/Serialization/Json/OkContentNormalizer.php
@@ -113,4 +113,11 @@ class OkContentNormalizer implements NormalizerInterface, SerializerAwareInterfa
     {
         return is_object($data) && $data instanceof OkContent;
     }
+
+    public function getSupportedTypes(?string $format): array
+    {
+        return [
+            OkContent::class => true,
+        ];
+    }
 }


### PR DESCRIPTION
This is a new (optional for now) method available for Symfony 6.3. It will be required in Symfony 7. Let's be prepared for the future (and suppress a warning at the same time).