### PR TITLE
:sparkles: Allow to override the data mapper of the api type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.10.4] 2024-06-25
 
 ### Added
-- Fix version for Symfony 7 #79
+- Add support for any version of Symfony 7 #79
+- Make the Melodiia data mapper a service so it's overridable more easily globally #78
 
 ## [0.10.3] 2024-06-04
 

--- a/src/DependencyInjection/MelodiiaExtension.php
+++ b/src/DependencyInjection/MelodiiaExtension.php
@@ -42,6 +42,8 @@ class MelodiiaExtension extends Extension
             if ($container->hasAlias('melodiia.data_provider')) {
                 $loader->load('crud.yaml');
             }
+
+            $loader->load('form.yaml');
         }
 
         if (class_exists(Environment::class)) {

--- a/src/Resources/config/form.yaml
+++ b/src/Resources/config/form.yaml
@@ -1,0 +1,9 @@
+services:
+    melodiia.form.data_mapper:
+        class: SwagIndustries\Melodiia\Form\DomainObjectsDataMapper
+
+    SwagIndustries\Melodiia\Form\Type\ApiType:
+        arguments:
+            $dataMapper: '@melodiia.form.data_mapper'
+        tags:
+            - { name: 'form.type' }


### PR DESCRIPTION
With this feature you can now override the data_mapper easily!

Here is how:

```yaml
services:
    melodiia.form.data_mapper:
        class: You\Awesome\DataMapper
```

It's useful because sometimes you wan to stay with the datamapper optional and have a default one as a service globally. It's a little improvement but nice.
