### PR TITLE
Remove sf 5 compatibility + update workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,14 +18,14 @@ jobs:
             -   name: Setup PHP
                 uses: shivammathur/setup-php@v2
                 with:
-                    php-version: 8.2
+                    php-version: 8.3
 
             -   uses: actions/cache@v2
                 id: cache-composer
                 with:
                     path: ~/.composer/cache
-                    key: composer-php-8.2-${{ github.sha }}
-                    restore-keys: composer-php-8.2-
+                    key: composer-php-8.3-${{ github.sha }}
+                    restore-keys: composer-php-8.3-
 
             -   name: Install dependencies
                 run: composer update --prefer-dist --no-progress --no-suggest
@@ -72,7 +72,7 @@ jobs:
         name: Functionnal tests
         strategy:
             matrix:
-                php: [ 8.1, 8.2 ]
+                php: [ 8.1, 8.2, 8.3 ]
                 os: [ ubuntu-latest ]
                 include:
                     -   os: [ ubuntu-latest ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
                 run: make test.composer
 
             -   name: Install dependencies
-                run: composer update --prefer-dist --no-progress --no-suggest --no-plugins ${{ matrix.composer-flag }}
+                run: composer update --prefer-dist --no-progress --no-plugins ${{ matrix.composer-flag }}
 
             -   name: Run PHPUnit tests
                 run: make test.phpunit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,11 +37,11 @@ jobs:
         name: Unit tests
         strategy:
             matrix:
-                php: [ 8.1, 8.2, 8.3 ]
+                php: [ 8.2, 8.3 ]
                 os: [ ubuntu-latest ]
                 include:
                     -   os: [ ubuntu-latest ]
-                        php: 8.0
+                        php: 8.1
                         composer-flag: "'--prefer-lowest'"
 
         runs-on: ${{ matrix.os }}
@@ -72,11 +72,11 @@ jobs:
         name: Functionnal tests
         strategy:
             matrix:
-                php: [ 8.1, 8.2, 8.3 ]
+                php: [ 8.2, 8.3 ]
                 os: [ ubuntu-latest ]
                 include:
                     -   os: [ ubuntu-latest ]
-                        php: 8.0
+                        php: 8.1
                         composer-flag: "'--prefer-lowest'"
 
         runs-on: ${{ matrix.os }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- Support for Symfony 5 #83
+- Support for PHP 8.0 #83
+
 ## [0.10.4] 2024-06-25
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -10,10 +10,10 @@
     "require": {
         "php": ">=8.0",
         "nekland/tools": "^2.5.1",
-        "symfony/event-dispatcher": "^5.3 || ^6.0 || ^7.0",
+        "symfony/event-dispatcher": "^6.0 || ^7.0",
         "pagerfanta/pagerfanta": "^2.0.1 || ^3.0.0",
-        "symfony/yaml": "^5.3 || ^6.0 || ^7.0",
-        "symfony/serializer": "^5.3.12 || ^6.0 || ^7.0",
+        "symfony/yaml": "^6.0 || ^7.0",
+        "symfony/serializer": "^6.0 || ^7.0",
         "pagerfanta/doctrine-orm-adapter": "^3.5"
     },
     "require-dev": {
@@ -32,19 +32,19 @@
         "monolog/monolog": "^3.4 || ^2.9",
         "masterminds/html5": "^2.8",
         "phpspec/prophecy-phpunit": "^2.0.0",
-        "symfony/dotenv": "^5.3 || ^6.0 || ^7.0",
-        "symfony/security-bundle": "^5.4.20 || ^6.2.6 || ^7.0",
-        "symfony/twig-bundle": "^5.3 || ^6.0 || ^7.0",
+        "symfony/dotenv": "^6.0 || ^7.0",
+        "symfony/security-bundle": "^6.2.6 || ^7.0",
+        "symfony/twig-bundle": "^6.0 || ^7.0",
         "symfony/web-profiler-bundle": "^5.3 || ^6.0 || ^7.0",
-        "symfony/asset": "^5.3 || ^6.0 || ^7.0",
-        "symfony/form": "^5.3 || ^6.0 || ^7.0",
-        "symfony/validator": "^5.3 || ^6.0 || ^7.0",
-        "symfony/framework-bundle": "^5.3 || ^6.0 || ^7.0",
-        "symfony/dependency-injection": "^5.3 || ^6.0 || ^7.0",
-        "symfony/config": "^5.3 || ^6.0 || ^7.0",
-        "symfony/proxy-manager-bridge": "^5.3 || ^6.4",
-        "symfony/browser-kit": "^5.3 || ^6.0 || ^7.0",
-        "symfony/doctrine-bridge": "^5.3 || ^6.0 || ^7.0"
+        "symfony/asset": "^6.0 || ^7.0",
+        "symfony/form": "^6.0 || ^7.0",
+        "symfony/validator": "^6.0 || ^7.0",
+        "symfony/framework-bundle": "^6.0 || ^7.0",
+        "symfony/dependency-injection": "^6.0 || ^7.0",
+        "symfony/config": "^6.0 || ^7.0",
+        "symfony/proxy-manager-bridge": "^6.4",
+        "symfony/browser-kit": "^6.0 || ^7.0",
+        "symfony/doctrine-bridge": "^6.0 || ^7.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -63,10 +63,6 @@
         {
             "name": "Maxime Veber",
             "email": "nek.dev@gmail.com"
-        },
-        {
-            "name": "BiiG",
-            "homepage": "https://www.biig.fr"
         }
     ]
 }

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "post-install-cmd": "make hooks.install"
     },
     "require": {
-        "php": ">=8.0",
+        "php": ">=8.1",
         "nekland/tools": "^2.5.1",
         "symfony/event-dispatcher": "^6.0 || ^7.0",
         "pagerfanta/pagerfanta": "^2.0.1 || ^3.0.0",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "psr/container": "^v1.1.1 || ^2.0",
         "phpunit/phpunit": "^9.6 || ^10.0.0 || ^11.1.3",
         "friendsofphp/php-cs-fixer": "3.58.0",
-        "phpspec/prophecy": "^1.8",
+        "phpspec/prophecy": "^1.19",
         "twig/twig": "^2.5 || ^3.10",
         "doctrine/orm": "^2.6.6 || ^2.17.0",
         "justinrainbow/json-schema": "^5.2",


### PR DESCRIPTION
As we update to Sf 6 as minimal version, we need to bump the minimal version of php as well! (Sf6 is for PHP 8.1+)