### PR TITLE
fix: OkContentNormalizer add page parameter in pagination when needed

### DIFF
--- a/features/crud.feature
+++ b/features/crud.feature
@@ -18,8 +18,8 @@ Feature:
       "links": {
         "prev": null,
         "next": null,
-        "last": "http://localhost/todos",
-        "first": "http://localhost/todos"
+        "last": "http://localhost/todos?page=1",
+        "first": "http://localhost/todos?page=1"
       },
       "data": [
         {
@@ -84,8 +84,8 @@ Feature:
       "links": {
         "prev": null,
         "next": null,
-        "last": "http://localhost/todos?q=ba",
-        "first": "http://localhost/todos?q=ba"
+        "last": "http://localhost/todos?q=ba&page=1",
+        "first": "http://localhost/todos?q=ba&page=1"
       },
       "data": [
         {

--- a/src/Serialization/Json/OkContentNormalizer.php
+++ b/src/Serialization/Json/OkContentNormalizer.php
@@ -68,18 +68,23 @@ class OkContentNormalizer implements NormalizerInterface, SerializerAwareInterfa
             $previousPage = null;
             $nextPage = null;
 
+            $hasPageParameter = str_contains($uri, 'page=');
+            $prefix = $uri . (str_contains($uri, '?') ? '&' : '?') . 'page=';
+
             if ($content->hasPreviousPage()) {
                 $previousPage = \preg_replace('/([?&])page=(\d+)/', '$1page=' . $content->getPreviousPage(), $uri);
             }
             if ($content->hasNextPage()) {
-                $nextPage = \preg_replace('/([?&])page=(\d+)/', '$1page=' . $content->getNextPage(), $uri);
+                $nextPage = $hasPageParameter
+                    ? preg_replace('/([?&])page=(\d+)/', '$1page=' . $content->getNextPage(), $uri)
+                    : $prefix . $content->getNextPage();
             }
 
             $result['links'] = [
                 'prev' => $previousPage,
                 'next' => $nextPage,
-                'last' => \preg_replace('/([?&])page=(\d+)/', '$1page=' . $content->getNbPages(), $uri),
-                'first' => \preg_replace('/([?&])page=(\d+)/', '$1page=1', $uri),
+                'last' => $hasPageParameter && 1 !== $content->getNbPages() ? \preg_replace('/([?&])page=(\d+)/', '$1page=' . $content->getNbPages(), $uri) : $prefix . $content->getNbPages(),
+                'first' => $hasPageParameter && 1 !== $content->getNbPages() ? \preg_replace('/([?&])page=(\d+)/', '$1page=1', $uri) : $prefix . 1,
             ];
         }
         if ($content instanceof Collection) {


### PR DESCRIPTION
**Problem:**
If I make a call without the page parameter, it will not be added for the pagination links